### PR TITLE
fix: prevent wrong-answer dialog from restarting after game over

### DIFF
--- a/src/pages/MarioGamePage.vue
+++ b/src/pages/MarioGamePage.vue
@@ -754,14 +754,16 @@ export default defineComponent({
             // 答錯時扣分並重置連續答對次數
             score.value = Math.max(0, score.value - 1000)
             consecutiveCorrect.value = 0 // 重置連續答對次數
-            showWrongAnswer.value = true
-            // 暫停遊戲
-            isGameRunning.value = false
 
             // 檢查是否遊戲結束
             if (score.value <= 0) {
+              showWrongAnswer.value = false
               showGameOver.value = true
               stopGame()
+            } else {
+              showWrongAnswer.value = true
+              // 暫停遊戲
+              isGameRunning.value = false
             }
           }
         }
@@ -836,6 +838,8 @@ export default defineComponent({
     }
 
     const continueAfterWrong = () => {
+      if (showGameOver.value) return
+
       // 重置跳跳人位置
       gameState.value.mario.x = 100
       gameState.value.mario.y = 400


### PR DESCRIPTION
## Summary

修正 Mario 遊戲在答錯扣分導致分數歸零時的 dialog 流程。原本會同時進入扣分與 Game Over 狀態，導致使用者按下扣分 dialog 的「繼續」後直接開始下一輪遊戲。現在只有在答錯後仍有分數時才顯示扣分 dialog，遊戲結束時必須由 Game Over dialog 的「再玩一次」重新開始。

## Changes

- 調整答錯扣分後的狀態判斷，分數歸零時只顯示遊戲結束 dialog。
- 答錯後分數仍大於 0 時，維持顯示扣分 dialog 並暫停遊戲。
- 在 continueAfterWrong() 加入 Game Over 狀態防護，避免已結束遊戲時被扣分 dialog 的繼續流程重啟。

## 詳細說明

扣分導致遊戲結束，會同時出現答錯 dialog 與遊戲結束 dialog

<img width="1307" height="921" alt="1782438932965" src="https://github.com/user-attachments/assets/6caf23d0-608f-41ee-bded-d9f2145d21b4" />

按下答錯 dialog 的繼續後，展示遊戲結束 dialog ，但此已經重新開啟新遊戲，用戶可以直接操作角色遊玩，並且在 dialog 上會顯示答案

<img width="1307" height="921" alt="1782438937680" src="https://github.com/user-attachments/assets/9cd01aa5-a68f-42ea-b623-e2a4b99c3448" />


https://github.com/user-attachments/assets/9873f1cb-ad78-41eb-92f0-ce0ce98ffbe0


