### PR TITLE
AI 後端 429 配額錯誤在前端正確呈現

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,7 +168,8 @@ Cloudflare Pages 自動部署：
 
 ## 陷阱
 
-- `src/pages/` 裡有多個歷史備份檔：`Game4Page_Backup20250111.vue`、`PlaybackPage_Backup20250131-2.vue`、`PlaybackPage＿Backup20250131.vue`（**全形底線**）、`PlaybackPage_Backup20250202WorkerAIOKVersion.vue`、`StoryPage_backend.vue`。做全域取代時**不要順手改到備份檔**，也不要拿它們當範本。
+- `src/pages/` 裡有多個歷史備份檔：`Game4Page_Backup20250111.vue`、`PlaybackPage_Backup20250131-2.vue`、`PlaybackPage＿Backup20250131.vue`（**全形底線**）、`PlaybackPage_Backup20250202WorkerAIOKVersion.vue`。做全域取代時**不要順手改到備份檔**，也不要拿它們當範本。
+- `StoryPage_backend.vue` 不是備份檔，而是由 `/story_backend` 路由的上線頁面；`_backend` 後綴表示它會呼叫後端，應像其他上線頁面一樣維護。
 - `src/views/` 是**孤立的死碼目錄**，不屬於現行結構。裡面只有 `Classics/ThreeCharacterPage.vue` 與 `Classics/CustomPage.vue`，而 `routes.ts` 沒有任何 `views/` 引用、`data/features.ts` 沒有對應項目、`src/` 與 `quasar.config.ts` 全庫零 import。**新頁面一律建在 `src/pages/`**；放進 `src/views/` 的檔案永遠不會被路由到。
 - `src-pwa/` 存在，但 `quasar.config.ts` 沒有啟用 PWA mode（`ssr.pwa: false`，無 `pwa` 區塊），`quasar build` 產出的是 SPA。修 PWA 行為前先確認是否真的有掛上 service worker。
 - **開工前先 `yarn install --immutable`。** `node_modules` 有可能與 `yarn.lock` 不同步（曾實測到樹上是 `vite-plugin-checker@0.14.3` + `quasar@2.20.0`，而 lockfile 鎖的是 `0.14.5` + `2.24.0`）。不同步時 `vite-plugin-checker` 會載入失敗，Quasar 只印一行 `⚠️ quasar.config file > invalid Vite plugin specified (cannot find it): vite-plugin-checker` 就**跳過整個型別檢查**，於是帶著型別錯誤的 build 也會 `Build succeeded`。看到那行 warning 就代表你的樹是壞的，先重裝，不要據此推論專案行為。

--- a/src/pages/CustomCardsPage.vue
+++ b/src/pages/CustomCardsPage.vue
@@ -213,6 +213,11 @@ import {
   ZH_TW_PREFERRED_KEYWORDS,
   speakTextWithPreferredVoice,
 } from 'src/utils/speechVoice'
+import {
+  parseAiFetchError,
+  notifyAiError,
+  notifyGenericError,
+} from 'src/utils/aiError'
 
 interface Card {
   english: string
@@ -388,12 +393,23 @@ export default defineComponent({
             body: JSON.stringify({ content: newCard.value.english }),
           },
         )
+        // fetch 不對 4xx 拋例外，必須手動檢查狀態碼
+        if (!response.ok) {
+          const quotaBody = await parseAiFetchError(response)
+          if (quotaBody !== null) {
+            notifyAiError($q, quotaBody)
+          } else {
+            notifyGenericError($q, '翻譯失敗，請稍後再試')
+          }
+          return
+        }
         const data = await response.json()
         console.log(data)
         newCard.value.chinese = data || ''
         console.log('newCard.value.chinese', newCard.value.chinese)
       } catch (error) {
         console.error('翻譯失敗:', error)
+        notifyGenericError($q, '翻譯失敗，請稍後再試')
       }
     }
     // 自動中翻英
@@ -409,12 +425,23 @@ export default defineComponent({
             body: JSON.stringify({ content: newCard.value.chinese }),
           },
         )
+        // fetch 不對 4xx 拋例外，必須手動檢查狀態碼
+        if (!response.ok) {
+          const quotaBody = await parseAiFetchError(response)
+          if (quotaBody !== null) {
+            notifyAiError($q, quotaBody)
+          } else {
+            notifyGenericError($q, '翻譯失敗，請稍後再試')
+          }
+          return
+        }
         const data = await response.json()
         console.log(data)
         newCard.value.english = data || ''
         console.log('newCard.value.english', newCard.value.english)
       } catch (error) {
         console.error('翻譯失敗:', error)
+        notifyGenericError($q, '翻譯失敗，請稍後再試')
       }
     }
 

--- a/src/pages/FavoritePage.vue
+++ b/src/pages/FavoritePage.vue
@@ -228,6 +228,7 @@ import FlashCard from 'src/components/FlashCard.vue'
 import axios from 'axios'
 import { useRoute } from 'vue-router'
 import { getVoicesAsync } from 'src/utils/speechVoice'
+import { parseAxiosAiError, notifyAiError, notifyGenericError } from 'src/utils/aiError'
 
 interface Card {
   english: string
@@ -660,15 +661,25 @@ export default defineComponent({
         audioPlayer.value.src = audioUrl
       }
 
-      // 上傳錄音檔案
-      const response = await axios.post(
-        'https://zh-en-backend.alearn13994229.workers.dev/convert-speech-to-text',
-        formData,
-        { headers: { 'Content-Type': 'multipart/form-data' } },
-      )
-      console.log(response.data)
-      console.log(response.data.text)
-      recordedText.value = response.data.text
+      // 上傳錄音檔案；axios 對 4xx/5xx 拋例外，必須 try/catch
+      try {
+        const response = await axios.post(
+          'https://zh-en-backend.alearn13994229.workers.dev/convert-speech-to-text',
+          formData,
+          { headers: { 'Content-Type': 'multipart/form-data' } },
+        )
+        console.log(response.data)
+        console.log(response.data.text)
+        recordedText.value = response.data.text
+      } catch (error) {
+        console.error('語音辨識失敗:', error)
+        const quotaBody = parseAxiosAiError(error)
+        if (quotaBody !== null) {
+          notifyAiError($q, quotaBody)
+        } else {
+          notifyGenericError($q, '語音辨識失敗，請稍後再試')
+        }
+      }
     }
 
     function resetAudio() {

--- a/src/pages/HandWrittenPage.vue
+++ b/src/pages/HandWrittenPage.vue
@@ -89,8 +89,10 @@
 
 <script lang="ts">
 import { defineComponent, ref, onMounted } from 'vue'
+import { useQuasar } from 'quasar'
 import axios from 'axios'
 import { speakEnglish } from 'src/utils/speechVoice'
+import { parseAxiosAiError, notifyAiError, notifyGenericError } from 'src/utils/aiError'
 
 export default defineComponent({
   name: 'HandWrittenPage',
@@ -101,6 +103,7 @@ export default defineComponent({
     },
   },
   setup() {
+    const $q = useQuasar()
     const canvas = ref<HTMLCanvasElement | null>(null)
     const ctx = ref<CanvasRenderingContext2D | null>(null)
     const isDrawing = ref(false)
@@ -313,6 +316,12 @@ export default defineComponent({
         }
       } catch (error) {
         console.error('Error checking answer:', error)
+        const quotaBody = parseAxiosAiError(error)
+        if (quotaBody !== null) {
+          notifyAiError($q, quotaBody)
+        } else {
+          notifyGenericError($q, '辨識失敗，請稍後再試')
+        }
       } finally {
         isChecking.value = false
       }

--- a/src/pages/PlaybackPage.vue
+++ b/src/pages/PlaybackPage.vue
@@ -107,7 +107,14 @@
 
 <script lang="ts">
 import { defineComponent, ref } from 'vue'
+import { useQuasar } from 'quasar'
 import { speakEnglish } from 'src/utils/speechVoice'
+import {
+  parseAiFetchError,
+  notifyAiError,
+  notifyGenericError,
+  QuotaError,
+} from 'src/utils/aiError'
 
 interface EmotionImageResult {
   images: string[]
@@ -126,6 +133,7 @@ export default defineComponent({
   name: 'PlaybackPage',
 
   setup() {
+    const $q = useQuasar()
     const userStory = ref('')
     const translatedStory = ref('')
     const emotions = ref<EmotionWithAnimation[]>([])
@@ -147,7 +155,15 @@ export default defineComponent({
           body: JSON.stringify({ content: story }),
         },
       )
-      if (!translateToZhResponse.ok) throw new Error('翻譯失敗')
+      // 先讀 body 才能解析配額錯誤，不能先 throw
+      if (!translateToZhResponse.ok) {
+        const quotaBody = await parseAiFetchError(translateToZhResponse)
+        if (quotaBody !== null) {
+          notifyAiError($q, quotaBody)
+          throw new QuotaError(quotaBody.error ?? '今日 AI 用量已達上限')
+        }
+        throw new Error('翻譯失敗')
+      }
 
       const data = await translateToZhResponse.text()
       translatedStory.value = data
@@ -167,7 +183,15 @@ export default defineComponent({
           body: JSON.stringify({ content: zhText }),
         },
       )
-      if (!analyzeEmotionsResponse.ok) throw new Error('情緒分析失敗')
+      // 先讀 body 才能解析配額錯誤，不能先 throw
+      if (!analyzeEmotionsResponse.ok) {
+        const quotaBody = await parseAiFetchError(analyzeEmotionsResponse)
+        if (quotaBody !== null) {
+          notifyAiError($q, quotaBody)
+          throw new QuotaError(quotaBody.error ?? '今日 AI 用量已達上限')
+        }
+        throw new Error('情緒分析失敗')
+      }
       const data = await analyzeEmotionsResponse.json()
 
       // 添加类型检查和空值处理
@@ -197,7 +221,15 @@ export default defineComponent({
         },
       )
 
-      if (!response.ok) throw new Error('圖片生成失敗')
+      // 先讀 body 才能解析配額錯誤，不能先 throw
+      if (!response.ok) {
+        const quotaBody = await parseAiFetchError(response)
+        if (quotaBody !== null) {
+          notifyAiError($q, quotaBody)
+          throw new QuotaError(quotaBody.error ?? '今日 AI 用量已達上限')
+        }
+        throw new Error('圖片生成失敗')
+      }
       const result = await response.json()
       return result as EmotionImageResult
     }
@@ -215,7 +247,15 @@ export default defineComponent({
           body: JSON.stringify({ content: `這個情緒是${zhEmotion}` }),
         },
       )
-      if (!response.ok) throw new Error('情緒翻譯失敗')
+      // 先讀 body 才能解析配額錯誤，不能先 throw
+      if (!response.ok) {
+        const quotaBody = await parseAiFetchError(response)
+        if (quotaBody !== null) {
+          notifyAiError($q, quotaBody)
+          throw new QuotaError(quotaBody.error ?? '今日 AI 用量已達上限')
+        }
+        throw new Error('情緒翻譯失敗')
+      }
       const enText = await response.text()
       return enText
     }
@@ -268,7 +308,11 @@ export default defineComponent({
 
         await animateEmotions(emotionResults)
       } catch (err) {
+        // QuotaError 已在內層 notify，此處只設 banner 訊息；其餘錯誤照舊
         error.value = err instanceof Error ? err.message : '分析過程發生錯誤，請稍後再試'
+        if (!(err instanceof QuotaError)) {
+          notifyGenericError($q, error.value)
+        }
       } finally {
         loading.value = false
         showProgress.value = false

--- a/src/pages/StoryPage_backend.vue
+++ b/src/pages/StoryPage_backend.vue
@@ -183,6 +183,11 @@
 <script lang="ts">
 import { ref, reactive, defineComponent } from 'vue'
 import { useQuasar } from 'quasar'
+import {
+  parseAiFetchError,
+  notifyAiError,
+  QuotaError,
+} from 'src/utils/aiError'
 
 export default defineComponent({
   name: 'StoryPageBackend',
@@ -273,7 +278,13 @@ export default defineComponent({
           },
         )
 
+        // 先讀 body 才能解析配額錯誤，不能先 throw
         if (!storyResponse.ok) {
+          const quotaBody = await parseAiFetchError(storyResponse)
+          if (quotaBody !== null) {
+            notifyAiError($q, quotaBody)
+            throw new QuotaError(quotaBody.error ?? '今日 AI 用量已達上限')
+          }
           throw new Error('故事生成失敗')
         }
 
@@ -301,7 +312,13 @@ export default defineComponent({
           },
         )
 
+        // 先讀 body 才能解析配額錯誤，不能先 throw
         if (!imagesResponse.ok) {
+          const quotaBody = await parseAiFetchError(imagesResponse)
+          if (quotaBody !== null) {
+            notifyAiError($q, quotaBody)
+            throw new QuotaError(quotaBody.error ?? '今日 AI 用量已達上限')
+          }
           throw new Error('圖片生成失敗')
         }
 
@@ -327,7 +344,13 @@ export default defineComponent({
           },
         )
 
+        // 先讀 body 才能解析配額錯誤，不能先 throw
         if (!voiceResponse.ok) {
+          const quotaBody = await parseAiFetchError(voiceResponse)
+          if (quotaBody !== null) {
+            notifyAiError($q, quotaBody)
+            throw new QuotaError(quotaBody.error ?? '今日 AI 用量已達上限')
+          }
           throw new Error('語音生成失敗')
         }
 
@@ -359,11 +382,14 @@ export default defineComponent({
           position: 'top',
         })
       } catch (error: unknown) {
-        $q.notify({
-          type: 'negative',
-          message: `發生錯誤：${error instanceof Error ? error.message : '請稍後重試'}`,
-          position: 'top',
-        })
+        if (!(error instanceof QuotaError)) {
+          // 配額錯誤已在拋出前 notify，此處只處理其他錯誤
+          $q.notify({
+            type: 'negative',
+            message: `發生錯誤：${error instanceof Error ? error.message : '請稍後重試'}`,
+            position: 'top',
+          })
+        }
         console.error('生成故事時發生錯誤：', error)
       } finally {
         loading.value = false

--- a/src/pages/WhatIsThisPage.vue
+++ b/src/pages/WhatIsThisPage.vue
@@ -95,6 +95,7 @@
 
 <script lang="ts">
 import { defineComponent, ref, onUnmounted } from 'vue'
+import { useQuasar } from 'quasar'
 import axios from 'axios'
 import heic2any from 'heic2any'
 import Pica from 'pica'
@@ -103,10 +104,12 @@ import {
   ZH_TW_PREFERRED_KEYWORDS,
   speakTextWithPreferredVoice,
 } from 'src/utils/speechVoice'
+import { parseAxiosAiError, notifyAiError, notifyGenericError } from 'src/utils/aiError'
 
 export default defineComponent({
   name: 'WhatIsThisPage',
   setup() {
+    const $q = useQuasar()
     const imageFile = ref(null)
     const imagePreview = ref('')
     const loading = ref(false)
@@ -344,7 +347,12 @@ export default defineComponent({
         resultZh.value = response.data.descriptionZh || response.data.description || ''
       } catch (error) {
         console.error('上傳圖片失敗:', error)
-        // 可以加入錯誤提示
+        const quotaBody = parseAxiosAiError(error)
+        if (quotaBody !== null) {
+          notifyAiError($q, quotaBody)
+        } else {
+          notifyGenericError($q, '圖片分析失敗，請稍後再試')
+        }
       } finally {
         loading.value = false
       }

--- a/src/utils/aiError.ts
+++ b/src/utils/aiError.ts
@@ -1,0 +1,134 @@
+/**
+ * aiError.ts — AI 後端配額錯誤的統一處理工具
+ *
+ * 後端在日用量達上限時回傳 HTTP 429，body 格式：
+ *   { code: "AI_DAILY_LIMIT_EXCEEDED", error: "...", retryAfterSeconds: 12345, status: 429, success: false }
+ *
+ * 本模組提供：
+ *   - parseAiFetchError   — 從 fetch Response 解析 429 body（async）
+ *   - parseAxiosAiError   — 從 axios 錯誤解析 429 body（sync）
+ *   - formatRetryAfter    — 將秒數格式化為繁體中文可讀提示
+ *   - notifyAiError       — 以 q-notify 顯示配額錯誤
+ *   - notifyGenericError  — 以 q-notify 顯示一般後端錯誤
+ *   - QuotaError          — 自訂例外類別，供已在拋出前 notify 的場景避免重複通知
+ */
+
+import type { QVueGlobals } from 'quasar'
+
+// ── 型別 ──────────────────────────────────────────────────────────────────────
+
+/** 後端 429 錯誤回應的 JSON 格式（欄位皆可能缺失） */
+interface BackendErrorBody {
+  code?: string
+  error?: string
+  retryAfterSeconds?: unknown
+  status?: number
+  success?: boolean
+}
+
+// ── 自訂例外 ──────────────────────────────────────────────────────────────────
+
+/**
+ * 代表 AI 配額超限的例外。
+ * 當拋出前已呼叫 notifyAiError 時，catch 區塊可檢查此型別以避免重複通知。
+ */
+export class QuotaError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'QuotaError'
+  }
+}
+
+// ── 私有輔助 ──────────────────────────────────────────────────────────────────
+
+/** 從任意值安全地取出 BackendErrorBody 物件（不丟例外） */
+function safeExtractBody(raw: unknown): BackendErrorBody {
+  if (raw !== null && typeof raw === 'object') return raw as BackendErrorBody
+  return {}
+}
+
+// ── 解析函式 ──────────────────────────────────────────────────────────────────
+
+/**
+ * 從 fetch Response 解析 AI 配額錯誤。
+ * 只在 response.ok 為 false 時呼叫。
+ *
+ * - status 429 → 嘗試解析 JSON body，回傳 body 物件（body 非 JSON 時回傳空物件）
+ * - 其他狀態碼 → 回傳 null，表示非配額錯誤
+ *
+ * 不會丟出例外。
+ */
+export async function parseAiFetchError(response: Response): Promise<BackendErrorBody | null> {
+  if (response.status !== 429) return null
+  try {
+    const raw: unknown = await response.json()
+    return safeExtractBody(raw)
+  } catch {
+    // body 不是有效 JSON（例如 edge proxy 回傳 HTML）
+    return {}
+  }
+}
+
+/**
+ * 從 axios 錯誤物件解析 AI 配額錯誤（在 catch 區塊中呼叫）。
+ *
+ * - error.response.status === 429 → 回傳解析後的 body 物件
+ * - 其他情況（網路錯誤、非 429）→ 回傳 null
+ *
+ * 不會丟出例外。
+ */
+export function parseAxiosAiError(error: unknown): BackendErrorBody | null {
+  if (error === null || typeof error !== 'object') return null
+  const e = error as { response?: { status?: unknown; data?: unknown } }
+  if (!e.response || e.response.status !== 429) return null
+  return safeExtractBody(e.response.data)
+}
+
+// ── 格式化 ────────────────────────────────────────────────────────────────────
+
+/**
+ * 將秒數格式化為繁體中文可讀的重試提示。
+ * 處理以下情況：
+ *   - 非數字、無限、負數、零 → 空字串
+ *   - < 60s → 「約 N 秒後可再試」
+ *   - < 1h  → 「約 N 分鐘後可再試」
+ *   - >= 1h → 「約 N 小時 M 分鐘後可再試」（整點時省略分鐘）
+ */
+export function formatRetryAfter(seconds: unknown): string {
+  if (typeof seconds !== 'number' || !isFinite(seconds) || seconds <= 0) return ''
+  const s = Math.round(seconds)
+  if (s < 60) return `約 ${s} 秒後可再試`
+  const m = Math.floor(s / 60)
+  if (m < 60) return `約 ${m} 分鐘後可再試`
+  const h = Math.floor(m / 60)
+  const rm = m % 60
+  return rm > 0 ? `約 ${h} 小時 ${rm} 分鐘後可再試` : `約 ${h} 小時後可再試`
+}
+
+// ── 通知函式 ──────────────────────────────────────────────────────────────────
+
+/**
+ * 以 q-notify 顯示 AI 配額錯誤。
+ * 主訊息取自 body.error（後備為固定中文提示），
+ * caption 為格式化後的重試等待時間（無時省略）。
+ */
+export function notifyAiError($q: QVueGlobals, body: BackendErrorBody): void {
+  const message =
+    typeof body.error === 'string' && body.error.trim()
+      ? body.error.trim()
+      : '今日 AI 用量已達上限，請明天再試'
+  const caption = formatRetryAfter(body.retryAfterSeconds)
+  // exactOptionalPropertyTypes: true 不允許明確傳入 undefined，
+  // 以 spread 條件式附加 caption 避免型別錯誤
+  $q.notify({ type: 'negative', message, ...(caption ? { caption } : {}), timeout: 8000 })
+}
+
+/**
+ * 以 q-notify 顯示一般後端錯誤（網路失敗、5xx 等非配額情況）。
+ */
+export function notifyGenericError($q: QVueGlobals, message?: string): void {
+  $q.notify({
+    type: 'negative',
+    message: message ?? '操作失敗，請稍後再試',
+  })
+}


### PR DESCRIPTION
close #116

## 問題背景

後端 `https://zh-en-backend.alearn13994229.workers.dev` 在日用量超限時回傳 HTTP 429：

```json
{"code":"AI_DAILY_LIMIT_EXCEEDED","error":"今日 AI 用量已達上限，請明天再試","retryAfterSeconds":12345,"status":429,"success":false}
```

修改前的狀況依頁面不同而有差異，分為兩類：

**完全沒有使用者可見的提示**（`CustomCardsPage`、`FavoritePage`、`HandWrittenPage`、`WhatIsThisPage`）：這四個頁面的 catch 只做 `console.error`，或完全沒有 try/catch（`FavoritePage.uploadAudio`），使用者看不到任何回饋。`CustomCardsPage` 另有更嚴重的 bug：`fetch` 對 4xx 不拋例外，`catch` 區塊是 HTTP 錯誤的死碼，429 回應的 body 物件被直接賦值給 `newCard.value.chinese`（string ref），在輸入框中顯示 `[object Object]`。

**有提示，但訊息是通用的**（`PlaybackPage`、`StoryPage_backend`）：這兩個頁面已有 `!response.ok` 檢查，並拋出本地化的通用錯誤字串（`翻譯失敗`、`情緒分析失敗`、`故事生成失敗` 等）——`PlaybackPage` 顯示於 q-banner，`StoryPage_backend` 顯示於 `$q.notify`。問題在於：`throw` 發生在讀取 response body 之前，429 的 JSON body（含 `error` 與 `retryAfterSeconds`）已無法取得，使用者只能看到通用錯誤，而非真正的配額超限訊息。

---

## 12 個 callsite，共 6 個路由頁面

### fetch 路徑（`fetch` 不對 4xx 拋例外，原有 `catch` 對 HTTP 錯誤是死碼）

| 頁面 | 端點 | 原問題 |
|------|------|--------|
| `CustomCardsPage.vue` | `POST /translate-en-to-zh` | **主要 bug**：無 `!response.ok` 檢查，429 body 賦值給 string ref → `[object Object]` |
| `CustomCardsPage.vue` | `POST /translate-zh-to-en` | 同上 |
| `PlaybackPage.vue` | `POST /translate-en-to-zh` | 有 `!response.ok` 但先 throw，body 已無法讀取 |
| `PlaybackPage.vue` | `POST /emotions` | 同上 |
| `PlaybackPage.vue` | `POST /playback/image` | 同上 |
| `PlaybackPage.vue` | `POST /translate-zh-to-en` | 同上 |
| `StoryPage_backend.vue` | `POST /StoryGeneration`（步驟 1） | 同上 |
| `StoryPage_backend.vue` | `POST /StoryGeneration`（步驟 2） | 同上 |
| `StoryPage_backend.vue` | `POST /StoryGeneration`（步驟 3） | 同上 |

### axios 路徑（axios 對 4xx 拋例外，但原有 `catch` 未處理或完全缺失）

| 頁面 | 端點 | 原問題 |
|------|------|--------|
| `FavoritePage.vue` | `POST /convert-speech-to-text` | **最嚴重**：無 try/catch，axios 429 → unhandled rejection，使用者零回饋 |
| `HandWrittenPage.vue` | `POST /detect-letter/...` | catch 只有 `console.error` |
| `WhatIsThisPage.vue` | `POST /detect-image-zh` | catch 只有 `console.error` |

---

## 新增檔案：`src/utils/aiError.ts`

提供統一的錯誤處理工具，完全型別安全（無 `any`），不丟例外：

- `parseAiFetchError(response)` — 從 fetch Response 解析 429 body（async）
- `parseAxiosAiError(error)` — 從 axios 錯誤解析 429 body（sync）
- `formatRetryAfter(seconds)` — 秒數 → 繁體中文可讀提示（處理 0、<60s、<1h、>=1h、缺失、非數字）
- `notifyAiError($q, body)` — q-notify 顯示配額錯誤，附重試提示 caption
- `notifyGenericError($q, message?)` — q-notify 顯示一般後端錯誤
- `QuotaError` — 自訂例外，供已在拋出前 notify 的場景避免重複通知

---

## 關於 `StoryPage_backend.vue`

此檔是上線頁面，由 `src/router/routes.ts` 的 `/story_backend` 路由提供服務，`_backend` 後綴表示「呼叫後端」。commit `5a55cfe` 已修正 `AGENTS.md` 中將其錯誤列為備份檔的說明。

---

## 成功路徑不變

所有頁面的正常回應行為與修改前完全一致。具體確認：

- 各頁面的成功賦值（`newCard.value.chinese = data || ''`、`recordedText.value = response.data.text` 等）逐字未動
- `finally` 區塊（重置 loading、spinner、showProgress 等）逐字未動
- `StoryPage_backend` 成功時的正向 notify「故事生成完成！」未動

---

## 驗證

**`yarn lint`** — 無任何輸出（零問題）。

**`yarn build`**（vue-tsc + ESLint 型別閘）：
```
Build succeeded
assets/aiError-DZb0HcM3.js  0.98 KB
```
無 TS 錯誤，無 `⚠️ invalid Vite plugin` 警告（確認型別檢查確實執行）。

**純函式驗證**（Node 22，throwaway script）：

| 輸入 | message | caption |
|------|---------|---------|
| 429 + 正確 JSON | 今日 AI 用量已達上限，請明天再試 | 約 3 小時 25 分鐘後可再試 |
| 429 + HTML body | 今日 AI 用量已達上限，請明天再試 | （無，正確後備） |
| 500 | null 回傳（非配額錯誤） | — |
| axios 429 | 今日 AI 用量已達上限，請明天再試 | 約 3 小時 25 分鐘後可再試 |
| 網路錯誤 | null 回傳（正確） | — |
| 200 成功 | null 回傳（正確，不觸發） | — |

**Headless Chrome CDP 即時瀏覽器驗證**（Chrome 151，`Fetch.enable` 攔截後端請求並注入 429 body）：

**fetch 路徑 — `/custom_cards`**：
- 攔截 `OPTIONS` → 204（preflight 通過），`POST /translate-en-to-zh` → 429 quota JSON
- DOM 讀取：`.q-notification` 文字為「**今日 AI 用量已達上限，請明天再試**」/「**約 3 小時 25 分鐘後可再試**」
- 中文 textarea 值：`""`（非 `[object Object]`，bug 修復確認）
- console：無錯誤（catch 分支未執行）

**axios 路徑 — `/what_is_this`**：
- 攔截 `POST /detect-image-zh` → 429 quota JSON
- DOM 讀取：`.q-notification` 文字為「**今日 AI 用量已達上限，請明天再試**」/「**約 3 小時 25 分鐘後可再試**」
- spinner 數量：0（`finally { loading.value = false }` 正常執行）
- console：`AxiosError: Request failed with status code 429`（確認 axios 收到 429，catch 正確路由至 `notifyAiError`）

